### PR TITLE
Upload code coverage report to Code Climate in separate workflow

### DIFF
--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -1,0 +1,27 @@
+name: Upload coverage results to Code Climate
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Fetch coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-json
+          path: ${{github.workspace}}/coverage.json
+
+      - name: Upload coverage report to Code Climate
+        uses: paambaati/codeclimate-action@v5
+        with:
+          coverageLocations: |
+            ${{github.workspace}}/coverage.json:simplecov
+          env:
+            CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}


### PR DESCRIPTION
One of the jobs in the CI workflow uploads a code coverage report to Code Climate. To so this, it needs a secret. However, CI runs triggered by PRs from forks and Dependabot have no access to the repository secrets, so the upload fails.

Our branch protection rules restrict changes to master to PRs that pass CI checks, among them some Code Climate checks that depend on the coverage report. This means that PRs from forks and from Dependabot can never pass CI.

To work around this, add a separate workflow to upload the report, triggered by the workflow_run event, on the successful completion of the CI workflow. This new workflow will have access to the secrets, even if the triggering workflow did not. It will only fetch and upload the report.

The new workflow depends on the CI workflow having saved the coverage report as an artefact. That change will need to be done in a separate PR. The new workflow will run only if it's already on master, so it needs to land before the CI workflow changes to upload the artefact. It is expected to fail if the report artefact is not present, but this should not fail the CI build.