### PR TITLE
The Code Climate action apparently needs to run in a repo

### DIFF
--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -12,6 +12,8 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Fetch coverage report
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The Code Climate action, used to upload coverage reports appears to need to run in a git repo. Add a checkout action to check out the repo.