### PR TITLE
Revise coverage report workflow to generate the report too

### DIFF
--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -13,18 +13,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Fetch coverage report
-        uses: actions/download-artifact@v4
         with:
-          name: coverage-json
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
-      - name: Upload coverage report to Code Climate
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Generate and upload coverage report
         uses: paambaati/codeclimate-action@v5
         with:
-          coverageLocations: |
-            ${{github.workspace}}/coverage.json:simplecov
+          coverageCommand: bundle exec rspec
         env:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}


### PR DESCRIPTION
The attempt to upload the code coverage report in a separate workflow has been an exercise in frustration.

The initial plan was to generate the report in the test job of the CI workflow, save it as an artefact, then download the artefact in the coverage report workflow and upload it to Code Climate there.

Unfortunately, for this to work the coverage report workflow needs to check out the revision of the repo on which the report was generated. Code Climate must associate the coverage report with the revision that generated so that it can calculate the coverage diffs for, and the only way in which the Code Climate action can get this is from the currently checked-out revision.

Frankly, if we're going to have to check the revision out, we may as well just generate the report in this workflow too, and not mess around with artefacts. The tests don't take long to run, anyway.