### PR TITLE
Revert to passing the coverage report as an artefact

### DIFF
--- a/.github/workflows/upload_coverage.yml
+++ b/.github/workflows/upload_coverage.yml
@@ -16,15 +16,17 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Fetch coverage report
+        uses: actions/download-artifact@v4
         with:
-          ruby-version: 3.3
-          bundler-cache: true
+          name: coverage-json
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate and upload coverage report
+      - name: Upload coverage report to Code Climate
         uses: paambaati/codeclimate-action@v5
         with:
-          coverageCommand: bundle exec rspec
+          coverageLocations: |
+            ${{github.workspace}}/coverage.json:simplecov
         env:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}


### PR DESCRIPTION
There is actually a point to passing the code coverage report around as an artefact. The whole point of not giving PRs from forks access to secrets is to prevent untrusted code from accessing and possibly exposing them. That protection is moot if the coverage report action, which does have access to the secrets, then runs the same untrusted code later to generate the report.

While we may need to check out the same revision on which the report was generated, that doesn't mean we should run the code in it!